### PR TITLE
BoardConfig.mk: remove BOARD_CHARGER_DISABLE_INIT_BLANK

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -47,7 +47,6 @@ DEVICE_FRAMEWORK_MANIFEST_FILE := $(DEVICE_PATH)/framework_manifest.xml
 
 # Offline charging
 BOARD_CHARGER_ENABLE_SUSPEND := true
-BOARD_CHARGER_DISABLE_INIT_BLANK := true
 BOARD_HEALTHD_CUSTOM_CHARGER_RES := $(DEVICE_PATH)/charger/images
 
 # Partitions


### PR DESCRIPTION
the following config causes flicker in offline charging mode on VPX23 - needs to be replaced by 'ro.charger.disable_init_blank=true' property for device who needs the config enabled